### PR TITLE
fixed xib loading bug for cocoapod frameworks

### DIFF
--- a/MYSForms/MYSForms/MYSFormViewController.m
+++ b/MYSForms/MYSForms/MYSFormViewController.m
@@ -723,7 +723,7 @@
 
 - (void)registerCellForClass:(Class)cellClass
 {
-    UINib *nib = [UINib nibWithNibName:NSStringFromClass(cellClass) bundle:[NSBundle bundleForClass:[MYSFormViewController class]]];
+    UINib *nib = [UINib nibWithNibName:NSStringFromClass(cellClass) bundle:[NSBundle bundleForClass:cellClass]];
     [self.collectionView registerNib:nib forCellWithReuseIdentifier:NSStringFromClass(cellClass)];
 }
 

--- a/MYSForms/MYSForms/MYSFormViewController.m
+++ b/MYSForms/MYSForms/MYSFormViewController.m
@@ -723,7 +723,7 @@
 
 - (void)registerCellForClass:(Class)cellClass
 {
-    UINib *nib = [UINib nibWithNibName:NSStringFromClass(cellClass) bundle:nil];
+    UINib *nib = [UINib nibWithNibName:NSStringFromClass(cellClass) bundle:[NSBundle bundleForClass:[MYSFormViewController class]]];
     [self.collectionView registerNib:nib forCellWithReuseIdentifier:NSStringFromClass(cellClass)];
 }
 


### PR DESCRIPTION
This fixes a bug introduced by Cocoapod frameworks with the `use_frameworks!` flag in podfiles.

`Could not load NIB in bundle: 'NSBundle </var/mobile/Containers/Bundle/Application/5D8D9F75-F790-4008-B9B3-DC0E8C811AA7/MyApp.app> (loaded)' with name 'MYSFormLabelCell`

It was occurring because framework pods have their own separate resource bundles and with a `nil` bundle parameter, the default bundle looked in was the main bundle of the app which did not contain any of the `.xib` resources.
